### PR TITLE
Fix: Atlas singleton

### DIFF
--- a/DJT.Azure.Atlas/Atlas.cs
+++ b/DJT.Azure.Atlas/Atlas.cs
@@ -9,8 +9,12 @@ namespace DJT.Azure.Atlas
     public class Atlas
     {
         
-        private string? secretKey = null;
-        public string Secret { set { secretKey = value; } }
+        private static string? secretKey = null;
+
+        /// <summary>
+        /// Secret Atlas key
+        /// </summary>
+        public static string Secret { set { secretKey = value; } }
 
         private static Atlas? _atlas;
         /// <summary>
@@ -19,22 +23,20 @@ namespace DJT.Azure.Atlas
         /// </summary>
         /// <returns></returns>
         /// <exception cref="ArgumentException"></exception>
-        public Atlas GetInstance()
+        public static Atlas GetInstance()
         {
             if (string.IsNullOrWhiteSpace(secretKey))
                 throw new ArgumentException("Secret not set in Atlas");
             if (_atlas == null)
-                _atlas = new Atlas(secretKey);
+                _atlas = new Atlas();
             return _atlas;
         }
 
         /// <summary>
         /// Construct this helper with the secret key
         /// </summary>
-        /// <param name="SecretKey"></param>
-        private Atlas(string SecretKey)
+        private Atlas()
         {
-            secretKey = SecretKey;
         }
 
         /// <summary>

--- a/DJT.Azure.Atlas/DJT.Azure.Atlas.csproj
+++ b/DJT.Azure.Atlas/DJT.Azure.Atlas.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <Description>Helper singleton client class for using the Azure Maps API</Description>
     <RepositoryUrl>https://github.com/rombethor/DJT.Azure</RepositoryUrl>


### PR DESCRIPTION
The Atlas class was unusable due to a private constructor and being unable to set the secret key before the instantiation.
Now the appropriate usage should be:
```c#
//Set the secret
Atlas.Secret = "XXX";
//Then get the instance
var atlas = Atlas.GetInstance();
//Then use it
var coordinates = await atlas.FindCoordinatesForPostcode("PO1 1AA", "GB", 1);
```